### PR TITLE
set utf-8 charset for StringEntity

### DIFF
--- a/src/main/scala/com/github/sebrichards/postmark/PostmarkClient.scala
+++ b/src/main/scala/com/github/sebrichards/postmark/PostmarkClient.scala
@@ -12,6 +12,7 @@ import org.json4s.jackson.Serialization
 import org.slf4j.LoggerFactory
 
 import com.github.sebrichards.postmark.util.DateTimeSerializer
+import java.nio.charset.StandardCharsets
 
 /**
  * A client for Postmark.
@@ -41,7 +42,7 @@ class PostmarkClient(serverToken: String) {
 
     // Add message
     val messageJson = Serialization.write(message)
-    httpPost.setEntity(new StringEntity(messageJson))
+    httpPost.setEntity(new StringEntity(messageJson, StandardCharsets.UTF_8))
 
     // Execute
     val httpResponse = client.execute(httpPost)


### PR DESCRIPTION
Hi,

I had encoding trouble with utf-8 characters. StringEntity with no charset defined uses org.apache.http.protocol.HTTP.DEF_CONTENT_CHARSET = Consts.ISO_8859_1.
Since utf-8 is hardcoded in the content type header as well, I passed utf-8 charset to the constructor of StringEntity.
